### PR TITLE
Fix: several convert problems

### DIFF
--- a/services/MarkdownToTiddlyWikiService.ts
+++ b/services/MarkdownToTiddlyWikiService.ts
@@ -80,7 +80,27 @@ export function extractTagsFromMarkdownText(text: string): { tags: string[], new
 	return { tags: [...new Set(tags)], newText };
 }
 
+/**
+ * Converts a markdown string to a TiddlyWiki string.
+ * See the tests in tests/MarkdownToTiddlyWiki.test.ts for examples
+ * @param text  content of a markdown file
+ * @returns the content of the file converted to TiddlyWiki
+ */
 export function convertMarkdownToTiddlyWiki(text: string): string {
+	// Don't convert text in code blocks, surrounded by ```
+	let is_in_code_block = true;
+	let twText = text.split(/```/).map((block) => {
+		is_in_code_block = !is_in_code_block;
+		if (is_in_code_block) {
+			return block;
+		} else {
+			return convertMarkdownNotInACodeBlockToTiddlyWiki(block);
+		}
+	}).join('```');
+	return twText;
+}
+
+function convertMarkdownNotInACodeBlockToTiddlyWiki(text: string): string {
 	let twText = text;
 
 	// Replace Headings
@@ -96,7 +116,7 @@ export function convertMarkdownToTiddlyWiki(text: string): string {
 			return line;
 		}
 		const level = (match[1].replace(/\t/g, '    ').length / 2) + 1;
-		return '\t'.repeat(level - 1) + '*'.repeat(match[2].length) + match[3] + match[4];
+		return '*'.repeat(level) + match[3] + match[4];
 	}).join('\n');
 
 	// Replace Ordered Lists
@@ -105,23 +125,38 @@ export function convertMarkdownToTiddlyWiki(text: string): string {
 		if (!match) {
 			return line;
 		}
-		const level = (match[1].replace(/\t/g, '    ').length / 4) + 1;
+		const level = (match[1].replace(/\t/g, '    ').length / 3) + 1;
 		const prefix = '#'.repeat(level);
 		return prefix + match[3] + match[4];
 	}).join('\n');
 
-	// Replace Links
-	twText = twText.replace(/\[\[([^\]]+)\]\]/g, (match, p1) => {
-		const linkRegex = /((?:[^\[\]|\\]|\\.)+)(?:\|((?:[^\[\]|\\]|\\.)+))?/;
-		const linkMatch = linkRegex.exec(p1);
+	// Protect CamelCase words
+	twText = twText.replace(/([A-Z][a-z]+[A-Z][A-Za-z]*)/g, "~$1");
 
-		if (!linkMatch) return match;
+	// Replace Internal Links
+	twText = twText.replace(/(!?)\[\[([^\]]+)\]\]/g, (match, p0, p1) => {
+		const linkElement1 = p1.replace('~', '')
+		const optImg = p0 === '!' ? 'img' : '';
 
-		const linkElement1 = linkMatch[1];
-		const linkElement2 = linkMatch[2] ? linkMatch[2] : '';
+		// CamelCase links
+		if ( linkElement1.match(/^([A-Z][a-z]+[A-Z][A-Za-z]*)$/g) ) {
+			return `${linkElement1}`;
+		}
 
 		// Remove leading | character if there is no description
-		return `[[${linkElement2 ? `${linkElement2}|` : ''}${linkElement1}]]`;
+		return `[${optImg}[${linkElement1}]]`;
+	});
+
+	// Replace External Links
+	twText = twText.replace(/(!?)\[([^\[\]]+)\]\(([^()]+)\)/g, (match, p0, p1, p2) => {
+		const optImg = p0 === '!' ? 'img' : '';
+		const linkLabel = p1.replace('~', '')
+		const linkElement1 = p2.replace('~', '')
+		if ( linkLabel === linkElement1 ) {
+			return `[${optImg}[${linkElement1}]]`;
+		} else {
+			return `[${optImg}[${linkLabel}|${linkElement1}]]`;
+		}
 	});
 
 	// Replace Bold

--- a/services/TiddlyWikiToMarkdownService.ts
+++ b/services/TiddlyWikiToMarkdownService.ts
@@ -57,6 +57,12 @@ export async function writeObsidianMarkdownFiles(markdownArray: ObsidianMarkdown
 	}
 }
 
+/**
+ * Converts a TiddlyWiki tiddler to Markdown using regular expressions.
+ * See the test suite in tests/TiddlyWikiToMarkdown.test.ts for examples of the conversion.
+ * @param text content of a TiddlyWiki tiddler
+ * @returns the content of the tiddler converted to Markdown
+ */
 export function convertTiddlyWikiToMarkdown(text: string): string {
 	let markdownText = text;
 
@@ -69,23 +75,39 @@ export function convertTiddlyWikiToMarkdown(text: string): string {
 
 	const lines = markdownText.split("\n");
 	const markdownLines = [];
+	let in_code_block = false;
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
+		if (line === "```") {
+			in_code_block = !in_code_block;
+		}
+		// Ignore markup in code blocks
+		if (in_code_block) {
+			markdownLines.push(line);
+			continue;
+		}
 
 		// Replace Unordered Lists
-		let convertedLine = line.replace(/^(\s*)(\*+)(\s+)/g, (match, p1, p2, p3) => {
-			const level = p1.replace(/\t/g, "    ").length / 4 + 1;
-			return "  ".repeat(level - 1) + "-".repeat(p2.length) + p3;
+		let convertedLine = line.replace(/^(\s*)\*(\**)(\s+)/g, (match, p1, p2, p3) => {
+			return p2.replace(/\*/g, "  ") + "-" + p3;
 		});
 
 		// Replace Ordered Lists
-		convertedLine = convertedLine.replace(/^(\s*)(#+)(\s+)/g, (match, p1, p2, p3) => {
-			return p2.replace(/#/g, "1.") + p3;
+		convertedLine = convertedLine.replace(/^(\s*)#(#*)(\s+)/g, (match, p1, p2, p3) => {
+			return p2.replace(/#/g, "   ") + "1." + p3;
+		});
+
+		// CamelCase Links
+		convertedLine = convertedLine.replace(/(~?)([A-Z][a-z]+[A-Z][A-Za-z]*)/g, (_, p1, p2) => {
+			if ( p1 === "~" ) return p2;
+			return '@((@' + p2 + '@))@';
 		});
 
 		// Replace Links 
-		convertedLine = convertedLine.replace(/\[\[(.+?)]]/g, (_, match) => {
+		convertedLine = convertedLine.replace(/\[(|img|ext)\[(.+?)]]/g, (_, p1, match) => {
+			match = match.replace(/@\(\(@/g, '');
+			match = match.replace(/@\)\)@/g, '');
 			const linkRegex = /([^\]|]+)(?:\|([^\]]+))?/;
 
 			const linkMatch = linkRegex.exec(match);
@@ -93,23 +115,37 @@ export function convertTiddlyWikiToMarkdown(text: string): string {
 
 			let linkElement1 = linkMatch[1];
 			let linkElement2 = linkMatch[2];
-
-			// Replace any remaining /, \, or : characters with underscores
-			linkElement1 = linkElement1.replace(/[\/\:]/g, "_");
-			if (linkElement2) {
-				linkElement2 = linkElement2.replace(/[\/\:]/g, "_");
+			if (!linkElement2 && linkElement1.includes("://")) {
+				// If no link text and link contains '://', use link as link text
+				linkElement2 = linkElement1;
 			}
 
-			// Swap
-			return "[[" + (linkElement2 ? linkElement2 + "|" + linkElement1 : linkElement1) + "]]";
+			// Format link
+			if (!linkElement2) {
+				if (p1 === "img") return `![[${linkElement1}]]`;
+				return `[[${linkElement1}]]`;
+			} else {
+				if (p1 === "img") return `![${linkElement1}](${linkElement2})`;
+				return `[${linkElement1}](${linkElement2})`;
+			}
 		});
 
+		// Replace temporary '@((@' with '[[' and '@))@' with ']]'
+		convertedLine = convertedLine.replace(/@\(\(@/g, '[[');
+		convertedLine = convertedLine.replace(/@\)\)@/g, ']]');
+		// Replace temporary '@(@' with '[' and '@)@' with ']'
+		convertedLine = convertedLine.replace(/@\(@/g, '[');
+		convertedLine = convertedLine.replace(/@\)@/g, ']');
+		// Replace temporary '@{@' with '(' and '@}@' with ')'
+		convertedLine = convertedLine.replace(/@\{@/g, '(');
+		convertedLine = convertedLine.replace(/@\}@/g, ')');
 
 		// Replace Bold
 		convertedLine = convertedLine.replace(/''(.+?)''/g, "**$1**");
 
 		// Replace Italic
-		convertedLine = convertedLine.replace(/\/\/(.+?)\/\//g, "_$1_");
+		convertedLine = convertedLine.replace(/([^:])\/\/(.+?)\/\//g, "$1_$2_"); 	// Ignore '://'
+		convertedLine = convertedLine.replace(/^\/\/(.+?)\/\//g, "_$1_");
 
 		// Replace Underline
 		convertedLine = convertedLine.replace(/__(.+?)__/g, "<u>$1</u>");
@@ -128,4 +164,3 @@ export function convertTiddlyWikiToMarkdown(text: string): string {
 
 	return markdownLines.join("\n");
 }
-

--- a/services/TiddlyWikiToMarkdownService.ts
+++ b/services/TiddlyWikiToMarkdownService.ts
@@ -79,7 +79,7 @@ export function convertTiddlyWikiToMarkdown(text: string): string {
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
-		if (line === "```") {
+		if (line.match(/^```[-a-z]*/)) {
 			in_code_block = !in_code_block;
 		}
 		// Ignore markup in code blocks
@@ -120,13 +120,15 @@ export function convertTiddlyWikiToMarkdown(text: string): string {
 				linkElement2 = linkElement1;
 			}
 
-			// Format link
+			// Format link: distinguish between internal and external links
+			let	optImg = p1 === "img" ? "!" : "";
+			// console.log(`Replace Links: $1: ${p1}, $2: ${linkElement1}, $3: ${linkElement2}`);
 			if (!linkElement2) {
-				if (p1 === "img") return `![[${linkElement1}]]`;
-				return `[[${linkElement1}]]`;
+				return `${optImg}[[${linkElement1}]]`;
+			} else if (linkElement2.includes("://")) {
+				return `${optImg}[${linkElement1}](${linkElement2})`;
 			} else {
-				if (p1 === "img") return `![${linkElement1}](${linkElement2})`;
-				return `[${linkElement1}](${linkElement2})`;
+				return `${optImg}[[${linkElement2}|${linkElement1}]]`;
 			}
 		});
 

--- a/tests/MarkdownToTiddlyWiki.test.ts
+++ b/tests/MarkdownToTiddlyWiki.test.ts
@@ -1,0 +1,9 @@
+import { convertMarkdownToTiddlyWiki } from "../services/MarkdownToTiddlyWikiService";
+import { TiddlyToMarkdownTestData, markdownTestData } from "./TiddlyWikiToMarkdown.test";
+
+describe("convert ", () => {
+    it.each<TiddlyToMarkdownTestData>(markdownTestData)("should convert a Markdown tiddler to TiddlyWiki", ({tiddlerText, expectedMarkdown}) => {
+            const convertedMarkdown = convertMarkdownToTiddlyWiki(expectedMarkdown);
+            expect(convertedMarkdown).toEqual(tiddlerText);
+        });
+});

--- a/tests/TiddlyWikiToMarkdown.test.ts
+++ b/tests/TiddlyWikiToMarkdown.test.ts
@@ -21,7 +21,7 @@ export const markdownTestData: TiddlyToMarkdownTestData[] = [
     },
     {
         tiddlerText: "Title different from page: [[Displayed Link Title|Tiddler Title]]",
-        expectedMarkdown: "Title different from page: [Displayed Link Title](Tiddler Title)"
+        expectedMarkdown: "Title different from page: [[Tiddler Title|Displayed Link Title]]"
     },
     {
         tiddlerText: "Two images: [img[Logo.png]] and external [img[https://tiddlywiki.com/favicon.ico]]",
@@ -43,6 +43,14 @@ export const markdownTestData: TiddlyToMarkdownTestData[] = [
         tiddlerText: `A numbered list:\n# First list item\n# Second list item\n## A subitem\n# Third list item`,
         expectedMarkdown: `A numbered list:\n1. First list item\n1. Second list item\n   1. A subitem\n1. Third list item`
     },
+    {
+        tiddlerText: `* Test CTA\n** Lead magnet\n*** Thank you page`,
+        expectedMarkdown: `- Test CTA\n  - Lead magnet\n    - Thank you page`
+    },
+    {   // Distinguish between internal links with display text and external links
+        tiddlerText: `* [[How to build a funnel 20/80|Funnel]]\n* See [[Internal Links|https://help.obsidian.md/Linking+notes+and+files/Internal+links]]`,
+        expectedMarkdown: `- [[Funnel|How to build a funnel 20/80]]\n- See [Internal Links](https://help.obsidian.md/Linking+notes+and+files/Internal+links)`
+    }
 ];
 
 describe("convert ", () => {

--- a/tests/TiddlyWikiToMarkdown.test.ts
+++ b/tests/TiddlyWikiToMarkdown.test.ts
@@ -1,0 +1,53 @@
+import { convertTiddlyWikiToMarkdown } from "../services/TiddlyWikiToMarkdownService";
+
+export type TiddlyToMarkdownTestData = { tiddlerText: string, expectedMarkdown: string };
+
+export const markdownTestData: TiddlyToMarkdownTestData[] = [
+    {
+        tiddlerText: "The ''quick'' brown ~~flea~~ fox //jumps// over the `lazy` dog",
+        expectedMarkdown: "The **quick** brown ~~flea~~ fox _jumps_ over the `lazy` dog"
+    },
+    {
+        tiddlerText: "This is a link to HelloThere, and one to [[History of TiddlyWiki]]",
+        expectedMarkdown: "This is a link to [[HelloThere]], and one to [[History of TiddlyWiki]]"
+    },
+    {   // URLs are not converted to links
+        tiddlerText: `https://tiddlywiki.com/ and [[TW5|https://tiddlywiki.com/]] are links`,
+        expectedMarkdown: `https://tiddlywiki.com/ and [TW5](https://tiddlywiki.com/) are links`
+    },
+    {
+        tiddlerText: "* ~HelloThere is not a link",
+        expectedMarkdown: "- HelloThere is not a link"
+    },
+    {
+        tiddlerText: "Title different from page: [[Displayed Link Title|Tiddler Title]]",
+        expectedMarkdown: "Title different from page: [Displayed Link Title](Tiddler Title)"
+    },
+    {
+        tiddlerText: "Two images: [img[Logo.png]] and external [img[https://tiddlywiki.com/favicon.ico]]",
+        expectedMarkdown: "Two images: ![[Logo.png]] and external ![https://tiddlywiki.com/favicon.ico](https://tiddlywiki.com/favicon.ico)"
+    },
+    {
+        tiddlerText: "```\nThis is a code block\n* Don't convert this to a list\n# A Comment\n! Not a header\n```",
+        expectedMarkdown: "```\nThis is a code block\n* Don't convert this to a list\n# A Comment\n! Not a header\n```",
+    },
+    {
+        tiddlerText: `! This is a level 1 heading\n!! This is a level 2 heading`,
+        expectedMarkdown: `# This is a level 1 heading\n## This is a level 2 heading`
+    },
+    {
+        tiddlerText: `* First list item\n* Second list item\n** A subitem\n* Third list item`,
+        expectedMarkdown: `- First list item\n- Second list item\n  - A subitem\n- Third list item`
+    },
+    {
+        tiddlerText: `A numbered list:\n# First list item\n# Second list item\n## A subitem\n# Third list item`,
+        expectedMarkdown: `A numbered list:\n1. First list item\n1. Second list item\n   1. A subitem\n1. Third list item`
+    },
+];
+
+describe("convert ", () => {
+    it.each<TiddlyToMarkdownTestData>(markdownTestData)("should convert a TiddlyWiki tiddler to Markdown", ({tiddlerText, expectedMarkdown}) => {
+            const convertedMarkdown = convertTiddlyWikiToMarkdown(tiddlerText);
+            expect(convertedMarkdown).toEqual(expectedMarkdown);
+        });
+})

--- a/tests/samples/from_markdown.tid
+++ b/tests/samples/from_markdown.tid
@@ -11,7 +11,7 @@ https://github.com/lucasbordeau/obsidian-tiddlywiki
 Principes clés :
 
 * [[Content marketing strategy]]
-* [[Funnel|How to build a funnel 20_80]]
+* [[Funnel|How to build a funnel 20/80]]
 * [[Buyer's journey]]
 
 ''Les différents axes à travailler :''
@@ -34,8 +34,8 @@ Principes clés :
 ''Phase capture d'un prospect :''
 
 * Test CTA
-	* Lead magnet
-		* Thank you page
+** Lead magnet
+*** Thank you page
 
 Phase `d'entretien` d'un prospect / nurture :
 

--- a/tests/samples/test.md
+++ b/tests/samples/test.md
@@ -11,7 +11,7 @@ https://github.com/lucasbordeau/obsidian-tiddlywiki
 Principes clés :
 
 - [[Content marketing strategy]]
-- [[How to build a funnel 20_80|Funnel]]
+- [[How to build a funnel 20/80|Funnel]]
 - [[Buyer's journey]]
 
 **Les différents axes à travailler :**

--- a/tests/samples/test.tid
+++ b/tests/samples/test.tid
@@ -18,7 +18,7 @@ Principes clés :
 
 //Phase identification du prospect ://
 
-* [[Customer / avatar]]
+* [[Customer _ avatar]]
 * Keyword ''research''
 * Content calendar
 
@@ -34,8 +34,8 @@ Principes clés :
 ''Phase capture d'un prospect :''
 
 * Test CTA
-	* Lead magnet
-		* Thank you page
+** Lead magnet
+*** Thank you page
 
 Phase `d'entretien` d'un prospect / nurture :
 


### PR DESCRIPTION
I have fixed several conversion problems when importing from or exporting to TiddlyWiki, notably:

- Mark-ups in code blocks converted mistakenly
- External links are converted to internal links with broken URLs (e.g. http:// -> http:__ )
- CamelCase links not converted
- Nested lists not converted properly

Added a new unit test file `tests/TiddlyWikiToMarkdown.test.ts` with a number of small test cases testing the mapping between Tiddly syntax to and from Markdown. Minor fixes in current test files.

Please note: Nested list items in TiddlyWiki are marked like:
```
* Level 1
** Level 2
*** Level 3
```
not by indented '*' or '#' characters, at least in the current version of TiddlyWiki, see https://tiddlywiki.com/#Lists%20in%20WikiText