### PR TITLE
Add tag normalization for Obsidian note conversion

### DIFF
--- a/src/modules/format-converters/convertObsidianNoteContentToTiddlerContent.ts
+++ b/src/modules/format-converters/convertObsidianNoteContentToTiddlerContent.ts
@@ -74,10 +74,6 @@ export function convertObsidianNoteContentToTiddlerContent(
             return line;
           }
 
-          console.log({
-            match,
-          });
-
           const [, tabs, , content] = match;
           // Calculate the level based on the number of leading tabs
           const level = (tabs ?? []).length + 1;

--- a/src/modules/format-converters/convertTiddlersToObsidianNotes.ts
+++ b/src/modules/format-converters/convertTiddlersToObsidianNotes.ts
@@ -1,13 +1,16 @@
 import { ObsidianNote } from 'src/modules/obsidian/types/ObsidianNote';
 import { Tiddler } from 'src/modules/tiddlywiki/types/Tiddler';
 import { convertTiddlerContentToObsidianNoteContent } from './convertTiddlerContentToObsidianNoteContent';
+import { parseAndNormalizeTags } from './parseAndNormalizeTiddlyWikiTagList';
 
 export function convertTiddlersToObsidianNotes(tiddlers: Tiddler[]) {
   const obsidianNotes: ObsidianNote[] = [];
 
   for (const tiddler of tiddlers) {
+    const normalizedTags = parseAndNormalizeTags(tiddler.tags ?? '');
+
     const frontMatter =
-      `---\n` + `${tiddler.tags ? `tags: ${tiddler.tags}\n` : ''}` + `---\n`;
+      `---\n` + `${tiddler.tags ? `tags: ${normalizedTags}\n` : ''}` + `---\n`;
 
     const content =
       frontMatter + convertTiddlerContentToObsidianNoteContent(tiddler.text);

--- a/src/modules/format-converters/parseAndNormalizeTiddlyWikiTagList.ts
+++ b/src/modules/format-converters/parseAndNormalizeTiddlyWikiTagList.ts
@@ -1,0 +1,14 @@
+export function parseAndNormalizeTags(tagList: string) {
+  // Function to normalize a tag
+  function normalizeTag(tag: string) {
+    return tag
+      .trim()
+      .replace(/ /g, '_') // Replace spaces with underscores
+      .normalize('NFD') // Decompose special characters into base form
+      .replace(/[\u0300-\u036f]/g, '') // Remove diacritics
+      .replace(/[^a-zA-Z0-9_]/g, ''); // Remove remaining non-alphanumeric characters
+  }
+
+  // Regex to match tags enclosed in [[ ]] and normalize them
+  return tagList.replace(/\[\[(.*?)\]\]/g, (match, tag) => normalizeTag(tag));
+}


### PR DESCRIPTION
Added tag normalization when converting TiddlyWiki tags that can have spaces and special chars.

Fixes https://github.com/lucasbordeau/obsidian-tiddlywiki/issues/15